### PR TITLE
Allow both CSV and fetching from db

### DIFF
--- a/include/util/constants.hpp
+++ b/include/util/constants.hpp
@@ -30,8 +30,12 @@ namespace constants {
         inline constexpr const char* TRAIN_RATIO = "train_ratio";
         inline constexpr const char* INPUT_FILE_PATH = "input_file_path";
         inline constexpr const char* METHOD = "method";
+        inline constexpr const char* DATA_SOURCE = "data_source";
+        inline constexpr const char* START_DATE = "start_date";
+        inline constexpr const char* END_DATE = "end_date";
+        inline constexpr const char* TICKER = "ticker";
         inline const std::set<std::string> ALL_PARAMS = {
-            ALPHA, BETA, STEPS_AHEAD, TRAIN_RATIO, INPUT_FILE_PATH, METHOD
+            ALPHA, BETA, STEPS_AHEAD, TRAIN_RATIO, INPUT_FILE_PATH, METHOD, DATA_SOURCE, START_DATE, END_DATE, TICKER
         };
     }
 
@@ -58,5 +62,13 @@ namespace constants {
             inline constexpr const char* SPY = "spy";
             inline constexpr const char* NDQ = "ndq";
         }
+    }
+
+    namespace datasource {
+        inline constexpr const char* CSV = "csv";
+        inline constexpr const char* DB = "db";
+        inline const std::set<std::string> ALL_DATASOURCES = {
+           CSV, DB
+        };
     }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -3,22 +3,7 @@
 #include "util/csv_manager.hpp"
 
 int main(int argc, const char * argv[]) {
-    // dynamically load csv on command line
-//    ForecastRunner runner;
-//    runner.run(argc, argv);
-    try {
-        MysqlService mysql_service;
-        std::vector<RowData> data = load_csv("data/ndq_20000101_20250606.csv");
-//        mysql_service.insert_history_data("ndq", data);
-//        mysql_service.insert_history_data("spx", data);
-        std::vector<RowData> results = mysql_service.load_history_data("ndq", "2020-01-01", "2020-01-05");
-        for(auto r : results) {
-            std::cout << r << std::endl;
-        }
-        return 0;
-    } catch (const std::exception& ex) {
-        std::cerr << "Fatal exception: " << ex.what() << "\n";
-        return 1;
-    }
+    ForecastRunner runner;
+    runner.run(argc, argv);
 }
 

--- a/src/forecast_runner.cpp
+++ b/src/forecast_runner.cpp
@@ -5,6 +5,7 @@
 #include "util/error_evaluator.hpp"
 #include "util/forecaster_registry.hpp"
 #include "util/constants.hpp"
+#include "service/mysql_service.hpp"
 
 #include <iostream>
 #include <memory>
@@ -13,8 +14,22 @@
 void ForecastRunner::run(int argc, const char* argv[]) {
     ArgParser arg_parser;
     arg_parser.parse(argc, argv);
+    
+    std::string data_source = arg_parser.get(constants::params::DATA_SOURCE);
+    std::vector<RowData> data;
+    if(data_source == constants::datasource::CSV) {
+        data = load_csv(arg_parser.get(constants::params::INPUT_FILE_PATH));
+    }
+    else {
+        std::string start_date = arg_parser.get(constants::params::START_DATE);
+        std::cout << "start_date: " << start_date << std::endl;
+        std::string end_date = arg_parser.get(constants::params::END_DATE);
+        std::cout << "end_date: " << end_date << std::endl;
+        std::string ticker = arg_parser.get(constants::params::TICKER);
+        MysqlService mysql_service;
+        data = mysql_service.load_history_data(ticker, start_date, end_date);
+    }
 
-    std::vector<RowData> data = load_csv(arg_parser.get(constants::params::INPUT_FILE_PATH));
     if (data.empty()) {
         throw std::runtime_error("Input CSV is empty.");
     }

--- a/src/service/mysql_service.cpp
+++ b/src/service/mysql_service.cpp
@@ -19,12 +19,23 @@ public:
         std::vector<RowData> data;
         mysqlx::Schema schema(session, history_data_schema);
         mysqlx::Table table = schema.getTable(get_table_name_from_ticker(ticker), true);
-        mysqlx:: RowResult res = table.select("DATE", "OPEN", "HIGH", "LOW", "CLOSE", "VOLUME")
+//        std::cout << "Using Schema: " << history_data_schema << std::endl;
+//        std::cout << "Using Table: " << table.getName() << std::endl;
+        
+        mysqlx:: RowResult res = table.select("CAST(DATE AS CHAR) AS DATE", "OPEN", "HIGH", "LOW", "CLOSE", "VOLUME")
                                         .where("DATE BETWEEN :start_date AND :end_date")
                                         .bind("start_date", start_date)
                                         .bind("end_date", end_date)
                                         .execute();
         for (const mysqlx::Row& row : res) {
+//            std::cout << "Number of Col: " << row.colCount() << std::endl;
+//            for (std::size_t i = 0; i < row.colCount(); ++i) {
+//                if (row[i].isNull()) {
+//                    std::cout << "NULL ";
+//                } else {
+//                    std::cout << row[i] << " ";
+//                }
+//            }
             data.emplace_back(
                 util::parse_date_string(row[0].get<std::string>()), // DATE
                 row[1].get<double>(), // OPEN

--- a/src/util/arg_parser.cpp
+++ b/src/util/arg_parser.cpp
@@ -8,7 +8,7 @@
 void ArgParser::parse(int argc, const char* argv[]) {
     initialize_specs();
     if (argc < 4) {
-        throw new std::invalid_argument("Required arguments: ./forecast_machine --input_file_path=... --method=... --evaluate(=true)/--forecast(=true)");
+        throw new std::invalid_argument("Required arguments: ./forecast_machine --data_source=... --method=... --evaluate(=true)/--forecast(=true)");
     }
     
     for (int i = 1; i < argc; ++i) {
@@ -33,11 +33,6 @@ const std::string& ArgParser::get(const std::string& key) const {
 }
 
 void ArgParser::validate_and_store(const std::string& key, const std::string& value) {
-    if(key == constants::params::INPUT_FILE_PATH) {
-        arg_map[constants::params::INPUT_FILE_PATH] = value;
-        return;
-    }
-    
     if (arg_specs.find(key) == arg_specs.end()) {
         throw std::runtime_error("Unknown argument: --" + key);
     }
@@ -102,5 +97,10 @@ void ArgParser::initialize_specs() {
     arg_specs[constants::params::METHOD] = ArgSpec::String(true, constants::methods::ALL_METHODS);
     arg_specs[constants::operations::FORECAST] = ArgSpec::Boolean(false);
     arg_specs[constants::operations::EVALUATE] = ArgSpec::Boolean(false);
+    arg_specs[constants::params::DATA_SOURCE] = ArgSpec::String(true, constants::datasource::ALL_DATASOURCES);
+    arg_specs[constants::params::INPUT_FILE_PATH] = ArgSpec::String(false);
+    arg_specs[constants::params::TICKER] = ArgSpec::String(false);
+    arg_specs[constants::params::START_DATE] = ArgSpec::String(false);
+    arg_specs[constants::params::END_DATE] = ArgSpec::String(false);
 }
 


### PR DESCRIPTION
Now both CSV and database fetch work:

sample command line args for using csv: 
`./build/Debug/forecast_engine --data_source=csv --input_file_path=data/ndq_20000101_20250606.csv  --method=holt --steps_ahead=25 --forecast=true `


sample command line args for using database in specified date range:
`./build/Debug/forecast_engine --data_source=db --ticker=ndq --start_date=2025-01-01 --end_date=2025-01-30 --method=holt --steps_ahead=15 --forecast=true`
 